### PR TITLE
Include proguard config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,29 +85,6 @@ expo install react-native-svg
 
 ## Troubleshooting
 
-### Problems with Proguard
-
-When Proguard is enabled (which it is by default for Android release builds), it causes runtime error.
-To avoid this, add an exception to `android/app/proguard-rules.pro`:
-
-```bash
--keep public class com.horcrux.svg.** {*;}
-```
-
-If you have build errors, then it might be caused by caching issues, please try:
-
-```bash
-watchman watch-del-all
-rm -fr $TMPDIR/react-*
-react-native start --reset-cache
-
-Or,
-
-rm -rf node_modules
-yarn
-react-native start --reset-cache
-```
-
 ### Unexpected behavior
 
 If you have unexpected behavior, please create a clean project with the latest versions of react-native and react-native-svg

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,8 @@ android {
         //noinspection OldTargetApi
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+        
+        consumerProguardFiles 'proguard-rules.pro'
     }
     lintOptions {
         abortOnError false

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep public class com.horcrux.svg.** {*;}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This will remove the requirement for people to add the proguard configs themselves. A lot of people first release to production with proguard and then realize why the app crashes. This will solve such issues.

This uses android's consumer proguard setting to enable specific proguard config.

## Test Plan

Example app works. All tests pass.

### What's required for testing (prerequisites)?

Example app works. All tests pass.

### What are the steps to reproduce (after prerequisites)?

Proguard enabled release should work without any manual edits to proguard file in the app.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
